### PR TITLE
Tick version to 7.3.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,6 +24,7 @@ requirements:
     
   run:
     - python
+    - setuptools
     - requests >=2.5.1,!=2.6.1,!=2.16.0,!=2.16.1
     - six >=1.3.0
     - urllib3

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,7 @@
 {% set name = "dropbox" %}
-{% set version = "7.2.1" %}
-{% set sha256 = "acb85a33b4f977de11facb7516b4e0c9d5325920e71a2a26d39df383d34fefec" %}
+{% set version = "7.3.1" %}
+{% set sha256 = "7383ff1a901701508a9767705725021dafb4587d0731132425653457d9ddc2e7" %}
+{% set build = 0 %}
 
 package:
   name: {{ name|lower }}
@@ -12,18 +13,19 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 0
+  number: {{ build }}
   script: python setup.py install --single-version-externally-managed --record record.txt
 
 requirements:
   build:
     - python
     - setuptools
+    - pytest-runner
+    
   run:
     - python
-    - setuptools
-    - requests
-    - six
+    - requests >=2.5.1,!=2.6.1,!=2.16.0,!=2.16.1
+    - six >=1.3.0
     - urllib3
 
 test:
@@ -31,11 +33,13 @@ test:
     - dropbox
 
 about:
-  home: http://github.com/dropbox/dropbox-sdk-python
+  home: https://github.com/dropbox/dropbox-sdk-python
   license: MIT
   license_family: MIT
   license_file: LICENSE
   summary: 'Official Dropbox API Client'
+  dev_url: https://github.com/dropbox/dropbox-sdk-python
+  doc_url: https://dropbox-sdk-python.readthedocs.io/en/latest/
 
   description: |
     dropbox is a Python SDK for integrating with the Dropbox API v2.


### PR DESCRIPTION
This pull updates the version to 7.3.1; I've tweaked the template slightly to add a "build" argument to the jinja.